### PR TITLE
Predict fixed, tests refactored with tomo TCL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+3.2.2:
+ Users:
+  - Hotfix: predict protocol was not setting the tilt series id to the generated tomograms.
+ Developers:
+  - Tests refactored using the Test Centralization Layer from scipion-em-tomo.
 3.2.1: Re-deploy to pypi
 3.2:
     - Use of odd even simplified and associated to the tomograms

--- a/cryocare/__init__.py
+++ b/cryocare/__init__.py
@@ -32,7 +32,7 @@ from cryocare.constants import CRYOCARE_ENV_ACTIVATION, DEFAULT_ACTIVATION_CMD, 
 
 _logo = "icon.png"
 _references = ['buchholz2019cryo']
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 
 class Plugin(pwem.Plugin):

--- a/cryocare/protocols/protocol_predict.py
+++ b/cryocare/protocols/protocol_predict.py
@@ -39,7 +39,6 @@ from cryocare import Plugin
 from tomo.objects import Tomogram, SetOfTomograms
 from cryocare.constants import PREDICT_CONFIG
 
-
 DENOISED_SUFFIX = 'denoised'
 EVEN = 'even'
 
@@ -135,14 +134,12 @@ tomograms followed by per-pixel averaging."""
                 self._insertFunctionStep(self.predictStep, tsId)
                 self._insertFunctionStep(self.createOutputStep, tsId)
 
-
     def _initialize(self):
         makePath(self._getPredictConfDir())
         if self.useIndependentOddEven.get():
             self.sRate = self.even.get().getSamplingRate()
         else:
             self.sRate = self.tomo.get().getSamplingRate()
-
 
     def preparePredictFullTomoStep(self, tsId, inputTomo):
         odd, even = inputTomo.getHalfMaps().split(',')
@@ -173,7 +170,8 @@ tomograms followed by per-pixel averaging."""
     def createOutputStep(self, tsId):
         outputSetOfTomo = getattr(self, outputObjects.tomograms.name, None)
         if not outputSetOfTomo:
-            outputSetOfTomo = SetOfTomograms.create(self._getPath(), template='tomograms%s.sqlite', suffix=DENOISED_SUFFIX)
+            outputSetOfTomo = SetOfTomograms.create(self._getPath(), template='tomograms%s.sqlite',
+                                                    suffix=DENOISED_SUFFIX)
             if self.useIndependentOddEven.get():
                 outputSetOfTomo.copyInfo(self.even.get())
             else:
@@ -226,10 +224,11 @@ tomograms followed by per-pixel averaging."""
         return outPathRe.sub('', outPath)
 
     def _getOutputFile(self, tsId):
-        return glob.glob(join(self._getOutputPath(tsId), '*.mrc'))[0] # Only one file is contained in each dir
+        return glob.glob(join(self._getOutputPath(tsId), '*.mrc'))[0]  # Only one file is contained in each dir
 
     def _genOutputTomogram(self, tsId):
         tomo = Tomogram()
         tomo.setLocation(self._getOutputFile(tsId))
         tomo.setSamplingRate(self.sRate)
+        tomo.setTsId(tsId)
         return tomo

--- a/cryocare/tests/__init__.py
+++ b/cryocare/tests/__init__.py
@@ -43,6 +43,9 @@ class DataSetCryoCARE(Enum):
     training_data_conf_dir = 'Training_Data_Config'
     training_data_conf = 'Training_Data_Config/training_data_config'
     training_data_model = CRYOCARE_MODEL_TGZ
+    sRate = 4.71
+    tomoDimensions = [618, 639, 104]
+    tomoSetSize = 1
 
 
 DataSet(name=CRYOCARE, folder=CRYOCARE, files={el.name: el.value for el in DataSetCryoCARE})


### PR DESCRIPTION
  - Hotfix: predict protocol was not setting the tilt series id to the generated tomograms.

  - Tests refactored using the Test Centralization Layer from scipion-em-tomo.