### PR TITLE
Make prediction robust to extensions of output file

### DIFF
--- a/cryocare/protocols/protocol_predict.py
+++ b/cryocare/protocols/protocol_predict.py
@@ -206,7 +206,7 @@ tomograms followed by per-pixel averaging."""
         return outPathRe.sub('', outPath)
 
     def _getOutputFile(self, tsId):
-        return glob.glob(join(self._getOutputPath(tsId), '*.mrc'))[0]  # Only one file is contained in each dir
+        return glob.glob(join(self._getOutputPath(tsId), '*'))[0]  # Only one file is contained in each dir
 
     def _genOutputTomogram(self, inTomo):
         tomo = Tomogram()


### PR DESCRIPTION
cryo-CARE uses the name and extension of the even tomogram for the output denoised tomogram, which is an annoying behavior but beyond our control. In this PR I make the protocol robust to different possible extensions of the generated output. Since there should be a single file in the output folder I believe this solution is safe.